### PR TITLE
Implement object ID. Document support for switches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Python control for Avion bluetooth dimmers
+Python control for Avion bluetooth dimmers and switches
 ==========================================
 
-A simple Python API for controlling [Avi-on](http://www.avi-on.com/) Bluetooth dimmers. This code makes use of the PyBT2 branch of Mike Ryan's [PyBT](http://github.com/mikeryan/PyBT) and depends on [csrmesh](https://github.com/nkaminski/csrmesh/).
+A simple Python API for controlling [Avi-on](http://www.avi-on.com/) Bluetooth dimmers and switches. This code makes use of the PyBT2 branch of Mike Ryan's [PyBT](http://github.com/mikeryan/PyBT) and depends on [csrmesh](https://github.com/nkaminski/csrmesh/).
 
 Example use
 -----------
@@ -20,4 +20,22 @@ import avion
 dimmer = avion.avion("00:21:4d:00:00:01", "O5bb9/ab8NvaDMnKYjpTGQ==")
 dimmer.connect()
 dimmer.set_brightness(0x80)
+```
+
+Specifying a device
+---------------
+
+Despite specifying a MAC address, the code above will set brightness on every Avi-on dimmer on the local mesh network. To control just one device, specify its object ID (integer starting from 1).
+
+```
+import avion
+
+dimmer = avion.avion("00:21:4d:00:00:01", "O5bb9/ab8NvaDMnKYjpTGQ==")
+dimmer.connect()
+
+# Set device 1 to 50% brightness.
+dimmer.set_brightness(0x80, 1)
+
+# Set device 2 to 100% brightness.
+dimmer.set_brightness(0xff, 2)
 ```

--- a/avion/__init__.py
+++ b/avion/__init__.py
@@ -57,8 +57,12 @@ class avion:
     except btle.BTLEException:
       raise avionException("Unable to connect")
 
-  def set_brightness(self, brightness):
-    packet = bytearray([0x80, 0x80, 0x73, 0x00, 0x0a, 0x00, 0x00, 0x00, brightness, 0x00, 0x00, 0x00, 0x00])
+  def set_brightness(self, brightness, object_id = 0):
+    obj_a = obj_b = 0x00
+    if object_id:
+      obj_a = 0x7f + object_id
+      obj_b = 0x80
+    packet = bytearray([obj_a, obj_b, 0x73, 0x00, 0x0a, 0x00, 0x00, 0x00, brightness, 0x00, 0x00, 0x00, 0x00])
     csrpacket = csrmesh.crypto.make_packet(self.password, csrmesh.crypto.random_seq(), packet)
     try:
       self.device.writeCharacteristic(self.lowhandle, csrpacket[0:20], withResponse=True)


### PR DESCRIPTION
## Object ID (support for controlling multiple devices)

Add a second parameter to `set_brightness` for specifying the [csrmesh object id](https://github.com/nkaminski/csrmesh#usage). Currently, `python-avion` sends commands to *all* connected devices, despite the fact that a MAC address is specified. I think that's a feature of csrmesh. This change allows control of specific switches, rather than controlling the entire network at once.

## Switches

I've verified that `python-avion` works with a (non-dimmer) [GE Smart Switch](https://www.amazon.com/GE-Bluetooth-Smart-Switch-13867/dp/B0134P957G/). This change updates the README accordingly.