### PR TITLE
Upgrade bluepy to 1.1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'Programming Language :: Python',
     ],
     install_requires=[
-        'bluepy==1.0.5',
+        'bluepy==1.1.4',
         'csrmesh==0.8.0',
     ],
     include_package_data=True,


### PR DESCRIPTION
When running locally I've seen issues with bluepy trying to parse it's uuids.json file incorrectly by trying to read too many values out of some of the json arrays. This manifests when importing avion - I get an exception like:

```
File "/srv/homeassistant/lib/python3.5/site-packages/bluepy/btle.py", line 707, in get_json_uuid
    for number,cname,name in uuid_data[k]:
ValueError: not enough values to unpack (expected 3, got 2)
```

Locally I updated bluepy to the latest 1.1.4 release which appears to work - it definitely contains the commit that removes the problematic json property (https://github.com/IanHarvey/bluepy/commit/6053be04845c2c7e4dcf8871613044fd15709667#diff-2839cfbad1aabd80516d98bf7fa42278)

I only have light switches and not dimmers to test with, but after updating bluepy locally the avion library appears to work fine.