### PR TITLE
Update csrmesh, add requests.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     ],
     install_requires=[
         'bluepy==1.0.5',
-        'csrmesh==0.8.0',
+        'csrmesh==0.9.0',
+        'requests==2.18.4',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
This PR updates the `csrmesh` dependency from `0.8` to `0.9`. It also adds `requests` to `setup.py`. No changes are made to the code.

## csrmesh

`csrmesh==0.8` [uses pycrypto](https://github.com/nkaminski/csrmesh/blob/0.8/setup.py#L21-L23), whereas `crsmesh==0.9` [has been updated to use pycryptodome](https://github.com/nkaminski/csrmesh/blob/0.9/setup.py#L21-L24).

#### Reasons to upgrade:

1. ["PyCrypto is dead."](https://github.com/dlitz/pycrypto/issues/238)
2. [Home Assistant has disallowed pycrypto](https://github.com/home-assistant/home-assistant/pull/12715).

## requests

[We use `requests`](https://github.com/mjg59/python-avion/blob/master/avion/__init__.py#L9), but it was missing from the setup.py file for some reason.