### PR TITLE
Update avion_info() to match Avi-on API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     ],
     install_requires=[
         'bluepy==1.0.5',
-        'csrmesh==0.8.0',
+        'csrmesh==0.9.0',
+        'requests==2.18.4',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Avi-on has changed their API in a way that breaks `avion.avion_info()` (see #7). This PR updates `avion.avion_info()` to use the new API.

I have tested the new code against Home Assistant to ensure that it maintains compatibility. Currently, Home Assistant fails get the list of devices. With this PR, it works again. No changes are needed on the Home Assistant side except for a version bump. I can open that PR as soon as a new version of `python-avion` is on PyPI.

This PR fixes issue #7.

**Note:** This PR also includes the dependency fix from #6. That change is also required for this library to continue working with Home Assistant.

## Output of `avion_info()` with this PR

The output matches the previous format as far as I can tell (based on Home Assistant code).

```
{'locations': [{'location': {'address': None,
    'avid': 1,
    'city': None,
    'country': None,
    'created_at': '2017-02-12T03:24:01+00:00',
    'devices': [{'device': {'avid': REDACTED,
       'countdown': None,
       'created_at': '2017-03-20T14:32:35+00:00',
       'current_version': '1.1.2',
       'device': None,
       'favorite': None,
       'friendly_mac_address': 'REDACTED',
       'group': None,
       'groups': [],
       'id': REDACTED,
       'last_active_at': None,
       'location_id': REDACTED,
       'mac_address': 'REDACTED',
       'mesh_status': 'available',
       'name': 'Kitchen Sink Light',
       'pid': 'REDACTED',
       'product': {'configurations': None,
         'deprecated': False,
         'features': ['ON_OFF', 'CLOCK', 'SCHEDULING', 'SCHEDULING_V2', 'SCENES', 'GROUPING', 'GROUPING_V2', 'POWER_CYCLE_OTA'],
         'firmware': {},
         'id': 6,
         'micro_controllers': 1,
         'name': 'GE Plug In Switch',
         'product_code': 5,
         'thumbnail': None,
         'vendor_code': 2,
         'vendor_id': 2,
         'vendor_name': 'JASCO'},
       'product_id': 6,
       'properties': [{'humanized': 'off',
         'id': REDACTED,
         'name': 'on_off',
         'operable': 'device',
         'operable_id': REDACTED,
         'updated_at': '2017-03-20T14:32:35+00:00',
         'value': '[0]'}],
       'remote_status': None,
       'schedules': [],
       'ssid': None,
       'target_id': None,
       'target_type': None,
       'thumbnail': '',
       'type': 'device',
       'updated_at': '2018-05-25T04:19:39+00:00',
       'versions': ['1.1.2']}}],
    'dst': 3600,
    'full_address': None,
    'id': REDACTED,
    'latest_version': '1.8.1',
    'latitude': None,
    'longitude': None,
    'merged_at': '2018-06-04T00:12:02+00:00',
    'merged_up': 'REDACTED',
    'name': 'Default Location',
    'passphrase': 'REDACTED',
    'pid': REDACTED,
    'regenerated_at': '2018-01-16T12:17:33+00:00',
    'state': None,
    'timezone': -14400,
    'updated_at': '2018-04-27T02:41:54+00:00'}}]}
```