### PR TITLE
API Update part 2, cleanup/re-factoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,58 @@ Python control for Avion bluetooth dimmers and switches
 
 A simple Python API for controlling [Avi-on](http://www.avi-on.com/) Bluetooth dimmers and switches. This code makes use of the PyBT2 branch of Mike Ryan's [PyBT](http://github.com/mikeryan/PyBT) and depends on [csrmesh](https://github.com/nkaminski/csrmesh/).
 
-Example use
------------
 
-This will connect and set the dimmer output to 50%. The second argument to the constructor is the network key which can be obtained by running:
+## Usage: With the Avion API (easy)
+
+This is the easy way to use the library. It uses the Avi-On API to get the devices in your account.
+
+```python
+import avion
+
+username = 'your-avion-username@example.com'
+password = 'your-avion-password'
+
+# Get all Avi-On devices in your account:
+devices = avion.get_devices(username, password)
+for device in avion.get_devices():
+    device.turn_on()
+    device.set_brightness(128)
+    device.turn_off()
+```
+
+By default, a connection won't be attempted until the first command is sent. To connect immediately, use `get_devices(username, password, connect=True)`.
+
+
+## Usage: Manual
+
+This is an alternative approach which does not require the Avi-On API.
+
+Get API key and password:
 
 ```
 curl -X POST -H "Content-Type: application/json" -d '{"email": "fakename@example.com", "password": "password"}' https://admin.avi-on.com/api/sessions | jq
 ```
 
-replacing the email and password fields with your Avion credentials. The "passphrase" field is the network key.
+Replace the email and password fields with your Avion credentials. The "passphrase" field is the API key.
 
-```
+Replace the MAC address and API key:
+
+```python
 import avion
 
-dimmer = avion.avion("00:21:4d:00:00:01", "O5bb9/ab8NvaDMnKYjpTGQ==")
+dimmer = avion.Avion("00:21:4d:00:00:01", "O5bb9/ab8NvaDMnKYjpTGQ==")
 dimmer.connect()
-dimmer.set_brightness(0x80)
+dimmer.set_brightness(255)
 ```
 
-Specifying a device
----------------
+Note: Despite specifying a MAC address, the code above will set brightness on
+every Avi-on dimmer on the local mesh network. To control just one device,
+you must specify its object ID (integer starting from 1).
 
-Despite specifying a MAC address, the code above will set brightness on every Avi-on dimmer on the local mesh network. To control just one device, specify its object ID (integer starting from 1).
-
-```
+```python
 import avion
 
-dimmer = avion.avion("00:21:4d:00:00:01", "O5bb9/ab8NvaDMnKYjpTGQ==")
+dimmer = avion.Avion("00:21:4d:00:00:01", "O5bb9/ab8NvaDMnKYjpTGQ==")
 dimmer.connect()
 
 # Set device 1 to 50% brightness.

--- a/avion/__init__.py
+++ b/avion/__init__.py
@@ -1,3 +1,4 @@
+
 # Python module for control of Avion bluetooth dimmers
 #
 # Copyright 2016 Matthew Garrett <mjg59@srcf.ucam.org>
@@ -7,92 +8,145 @@
 
 import csrmesh
 import requests
-import socket
-
 from bluepy import btle
 
-def send_packet(sock, handle, data):
-  packet = bytearray([0x12, handle, 0x00])
-  for item in data:
-    packet.append(item)
-  sock.send(packet)
-  data = sock.recv(32)
-  response = []
-  for d in data:
-    response.append(ord(d))
-  return response
 
-def read_packet(sock, handle):
-  packet = bytearray([0x0a, handle, 0x00])
-  sock.send(packet)
-  data = sock.recv(32)
-  response = []
-  for d in data:
-    response.append(ord(d))
-  return response
+def get_devices(username: str, password: str, connect: bool = False):
+    """Enumerate devices using the Avi-on API."""
+    API_URL = "https://api.avi-on.com/{api}"
+    API_AUTH = API_URL.format(api='sessions')
+    API_USER = API_URL.format(api='user')
+    API_DEVICES = API_URL.format(api='locations/{location}/abstract_devices')
 
-def avion_info(username, password):
-  """Enumerate devices using the Avi-On API."""
-  def _authenticate(username, password):
-    """Authenticate with the API and get a token."""
-    r = requests.post("https://api.avi-on.com/sessions",
-                      json={'email': username, 'password': password})
-    try:
-      return r.json()['credentials']['auth_token']
-    except KeyError:
-      raise(avionException('API authentication failed'))
+    def _authenticate(username, password):
+        """Authenticate with the API and get a token."""
+        auth_data = {'email': username, 'password': password}
+        r = requests.post(API_AUTH, json=auth_data)
+        try:
+            return r.json()['credentials']['auth_token']
+        except KeyError:
+            raise(AvionException('API authentication failed'))
 
-  def _get_locations(auth_token):
-    """Get a list of locations from the API."""
-    r = requests.get("https://api.avi-on.com/user",
-                     headers={'Authorization': 'Token {}'.format(auth_token)})
-    return r.json()['user']['locations']
+    def _get_locations(auth_token):
+        """Get a list of locations from the API."""
+        headers = {'Authorization': 'Token {}'.format(auth_token)}
+        r = requests.get(API_USER, headers=headers)
+        return r.json()['user']['locations']
 
-  def _get_devices(auth_token, location_id):
-    """Get a list of devices for a particular location."""
-    r = requests.get("https://api.avi-on.com/locations/{}/abstract_devices"
-                       .format(location_id),
-                     headers={'Authorization': 'Token {}'.format(auth_token)})
-    return r.json()['abstract_devices']
+    def _get_devices(auth_token, location_id):
+        """Get a list of devices for a particular location."""
+        headers = {'Authorization': 'Token {}'.format(auth_token)}
+        r = requests.get(API_DEVICES.format(location=location_id),
+                         headers=headers)
+        return r.json()['abstract_devices']
 
-  auth_token = _authenticate(username, password)
-  locations = _get_locations(auth_token)
-  for idx, location in enumerate(locations):
-    devices = _get_devices(auth_token, location['id'])
-    locations[idx]['devices'] = [{'device': d} for d in devices]
-  return {'locations': [{'location': l} for l in locations]}
+    auth_token = _authenticate(username, password)
+    locations = _get_locations(auth_token)
+    all_devices = []
+    for location_idx, location in enumerate(locations):
+        devices = _get_devices(auth_token, location['id'])
+        locations[location_idx]['devices'] = []
+        for device_id, device in enumerate(devices):
+            all_devices.append(Avion(
+                mac=''.join(l + ':' * (n % 2)
+                            for n, l in
+                            enumerate(device['friendly_mac_address']))[:17],
+                passphrase=location['passphrase'],
+                name=device['name'],
+                object_id=len(devices) - device_id,
+                connect=connect))
+
+    return all_devices
 
 
-class avionException(Exception):
-  pass
+class AvionException(Exception):
+    """An error related to an Avi-on bluetooth device."""
 
-class avion:
-  def __init__(self, mac, password):
-    self.mac = mac
-    password = password.encode("ascii") + bytearray([0x00, 0x4d, 0x43, 0x50])
-    self.password = csrmesh.crypto.generate_key(password)
+    pass
 
-  def connect(self):
-    try:
-      self.device = btle.Peripheral(self.mac, addrType=btle.ADDR_TYPE_PUBLIC)
-      characteristics = self.device.getCharacteristics()
-      for characteristic in characteristics:
-        if characteristic.uuid == "c4edc000-9daf-11e3-8003-00025b000b00":
-          self.lowhandle = characteristic.getHandle()
-        elif characteristic.uuid == "c4edc000-9daf-11e3-8004-00025b000b00":
-          self.highhandle = characteristic.getHandle()
-    except btle.BTLEException:
-      raise avionException("Unable to connect")
 
-  def set_brightness(self, brightness, object_id = 0):
-    obj_a = obj_b = 0x00
-    if object_id:
-      obj_a = 0x7f + object_id
-      obj_b = 0x80
-    packet = bytearray([obj_a, obj_b, 0x73, 0x00, 0x0a, 0x00, 0x00, 0x00, brightness, 0x00, 0x00, 0x00, 0x00])
-    csrpacket = csrmesh.crypto.make_packet(self.password, csrmesh.crypto.random_seq(), packet)
-    try:
-      self.device.writeCharacteristic(self.lowhandle, csrpacket[0:20], withResponse=True)
-      self.device.writeCharacteristic(self.highhandle, csrpacket[20:], withResponse=True)
-    except Exception as e:
-      raise avionException("Unable to send brightness command")
+class Avion:
+    """An Avi-on bluetooth device."""
+
+    CHARACTERISTIC_LOW = btle.UUID("c4edc000-9daf-11e3-8003-00025b000b00")
+    CHARACTERISTIC_HIGH = btle.UUID("c4edc000-9daf-11e3-8004-00025b000b00")
+    KEY_SUFFIX = bytearray([0x00, 0x4d, 0x43, 0x50])
+    BRIGHTNESS_PREFIX = bytearray([0x73, 0x00, 0x0a, 0x00, 0x00, 0x00])
+    BRIGHTNESS_SUFFIX = bytearray([0x00, 0x00, 0x00, 0x00])
+    DEFAULT_OBJECT = bytearray([0x00, 0x00])
+    DEFAULT_NAME = "Avi-On Switch"
+
+    def __init__(self, mac: str, passphrase: str, name: str = None,
+                 object_id: int = None, connect: bool = True):
+        """Configure and optionally connect to this device.
+
+        If using more than one Avi-on device, object_id is required to
+        distinguish devices. Otherwise all devices will switch together."""
+        self.name = name or self.DEFAULT_NAME
+        self.mac = mac
+        self.key = csrmesh.crypto.generate_key(
+            passphrase.encode("ascii") + self.KEY_SUFFIX)
+        self.object_id = object_id
+        self.device = None
+        if connect:
+            self.connect()
+
+    def __repr__(self):
+        """Representation of this object."""
+        return '<Avion name={name}, mac={mac}, id={object_id}>'.format(
+            name=self.name, mac=self.mac, object_id=self.object_id)
+
+    def connect(self):
+        """Connect to this device."""
+        try:
+            self.device = btle.Peripheral(self.mac,
+                                          addrType=btle.ADDR_TYPE_PUBLIC)
+        except btle.BTLEException:
+            raise AvionException("Failed to connect to device {mac}"
+                                 .format(mac=self.mac))
+        self._get_characteristic_handles()
+
+    def _get_characteristic_handles(self):
+        """Get high/low characteristic handles.
+
+        Communicates with the device to get the handles for the "high" and
+        "low" characteristics. These will later be used for sending commands.
+        """
+        try:
+            characteristics = self.device.getCharacteristics()
+            for characteristic in characteristics:
+                if characteristic.uuid == self.CHARACTERISTIC_LOW:
+                    self.handle_low = characteristic.getHandle()
+                elif characteristic.uuid == self.CHARACTERISTIC_HIGH:
+                    self.handle_high = characteristic.getHandle()
+        except btle.BTLEException:
+            raise AvionException("Failed to read characteristics for device "
+                                 "{mac}".format(mac=self.mac))
+
+    def set_brightness(self, brightness):
+        """Update the brightness of this device."""
+        if self.object_id:
+            object_bytes = bytearray([0x7f + self.object_id, 0x80])
+        else:
+            object_bytes = self.DEFAULT_OBJECT
+        packet = (object_bytes +
+                  self.BRIGHTNESS_PREFIX +
+                  bytearray([brightness]) +
+                  self.BRIGHTNESS_SUFFIX)
+        csrpacket = csrmesh.crypto.make_packet(
+            self.key, csrmesh.crypto.random_seq(), packet)
+        try:
+            self.device.writeCharacteristic(
+                self.handle_low, csrpacket[0:20], withResponse=True)
+            self.device.writeCharacteristic(
+                self.handle_high, csrpacket[20:], withResponse=True)
+        except Exception:
+            raise AvionException("Unable to send brightness command")
+
+    def turn_on(self):
+        """Turn the device on."""
+        self.set_brightness(255)
+
+    def turn_off(self):
+        """Turn the device off."""
+        self.set_brightness(0)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'Programming Language :: Python',
     ],
     install_requires=[
-        'bluepy==1.0.5',
+        'bluepy==1.1.4',
         'csrmesh==0.9.0',
         'requests==2.18.4',
     ],


### PR DESCRIPTION
This PR attempts to make the library easier to use.

- Refactored `avion_info()` into `get_devices()`, which now returns full `Avion` objects. Closes #7.
  - Added support for `object_id` (required for independent control of multiple devices).
- Added comments/docstrings, typehints for public API.
- Removed dead code (`send_packet`, `read_packet`).
- Updated/extended documentation.