### PR TITLE
Look up location ids from /locations instead of /user

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is an alternative approach which does not require the Avi-On API.
 Get API key and password:
 
 ```
-curl -X POST -H "Content-Type: application/json" -d '{"email": "fakename@example.com", "password": "password"}' https://admin.avi-on.com/api/sessions | jq
+curl -X POST -H "Content-Type: application/json" -d '{"email": "fakename@example.com", "password": "password"}' https://api.avi-on.com/sessions | jq
 ```
 
 Replace the email and password fields with your Avion credentials. The "passphrase" field is the API key.

--- a/avion/__init__.py
+++ b/avion/__init__.py
@@ -19,7 +19,7 @@ def get_devices(username: str, password: str, connect: bool = False):
     """Enumerate devices using the Avi-on API."""
     API_URL = "https://api.avi-on.com/{api}"
     API_AUTH = API_URL.format(api='sessions')
-    API_USER = API_URL.format(api='user')
+    API_LOCATION = API_URL.format(api='locations')
     API_DEVICES = API_URL.format(api='locations/{location}/abstract_devices')
 
     def _authenticate(username, password):
@@ -34,8 +34,8 @@ def get_devices(username: str, password: str, connect: bool = False):
     def _get_locations(auth_token):
         """Get a list of locations from the API."""
         headers = {'Authorization': 'Token {}'.format(auth_token)}
-        r = requests.get(API_USER, headers=headers, timeout=API_TIMEOUT)
-        return r.json()['user']['locations']
+        r = requests.get(API_LOCATION, headers=headers, timeout=API_TIMEOUT)
+        return r.json()['locations']
 
     def _get_devices(auth_token, location_id):
         """Get a list of devices for a particular location."""


### PR DESCRIPTION
Avi-On appears to have removed location information from the `/user` path, so now the code accesses it via the base /locations path.

This also updates the README with the new base url for the Avi-On API.

I've tested this on a raspberry pi running against a couple of GE Avi-On light switches.